### PR TITLE
Fix taxonomies definition typo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,7 +57,7 @@ hard_link_static = false
 #
 taxonomies = [
     { name = "categories", feed = true, paginate_by = 10 },
-    { name = "tags", fees = true, paginate_by = 10 },
+    { name = "tags", feed = true, paginate_by = 10 },
 ]
 
 # When set to "true", a search index is built from the pages and section


### PR DESCRIPTION
The tags taxonomy sets a "fees" attribute instead of "feed".